### PR TITLE
Split data collection into server (data collector) and client (used by web dashboard)

### DIFF
--- a/data-collection/README.md
+++ b/data-collection/README.md
@@ -40,3 +40,68 @@ This will create an `out` directory to put all output, and within that, each run
 
 It will look at how many IDs were requested in previous runs to figure out where
 it left off last time.
+
+## Running the data collection script
+
+Open up a terminal and make sure you're inside the `data-collection` directory.
+You can do this by running `cd ~/cyberlang-learning/data-collection`. The rest of these
+instructions assume you're in that directory.
+
+You'll need to install some packages before you can run stuff. Run `pip -r include.txt`
+to do that (this looks at the list of packages in [include.txt](./include.txt)).
+
+The script to run is in [`__main__.py`](./__main__.py). Normally, you'd run it with `python __main__.py`,
+but `__main__.py` is a special name, so you can also run it with the path to the folder the
+script is in. Here, you can run it with `python .` (`.` means "current directory").
+
+It's probably best to run with `python . -v` so you can see all the logs right there.
+
+Use the `--help` flag to get help (`python . --help`). Here are the options at the time of writing:
+```
+ python . --help
+usage: data-collection [-h] [--config-file CONFIG_FILE] [--output-dir OUTPUT_DIR] [--env-file ENV_FILE] [--verbose] [--silent] [--overwrite] [--recover]
+                       [--praw-log {info,debug,warn,error}] [--terminal]
+
+The Gems Reddit Data collector 9000 turdo
+
+options:
+  -h, --help            show this help message and exit
+  --config-file CONFIG_FILE, -c CONFIG_FILE
+  --output-dir OUTPUT_DIR
+                        ouput directory
+  --env-file ENV_FILE   the env file to use
+  --verbose, -v         will print all logging to screen
+  --silent              will log only errors
+  --overwrite, -o       if exsting files should be overwritten
+  --recover, -r         if we should recover from a existing file
+  --praw-log {info,debug,warn,error}, -p {info,debug,warn,error}
+                        Log level for PRAW output
+  --terminal            Run only in the terminal, instead of showing the web dashboard
+```
+
+## Running the web dashboard
+
+Open another terminal and again `cd` to `~/cyberlang-learning/data-collection`.
+
+Streamlit should've been installed already (it's listed in [include.txt](./include.txt)),
+but if it isn't installed, just run `pip install streamlit` to do that.
+
+Run `streamlit run webapp.py` to start the dashboard. You'll see something like this:
+```
+ streamlit run webapp.py
+
+  You can now view your Streamlit app in your browser.
+
+  Local URL: http://localhost:8501
+  Network URL: http://172.28.59.31:8501
+```
+
+Open up either one of those URLs in your browser.
+
+## How the dashboard works
+
+The server runs on port 1234. Every time it makes a request to Reddit and gets a
+response back, it makes a CSV string and sends it to the dashboard. Each row of this
+CSV corresponds to the data collected for a particular time range so far. The columns
+are the start date of the time range, the minimum number of comments needed from that
+range, the number of hits so far, and the number of misses so far.

--- a/data-collection/__main__.py
+++ b/data-collection/__main__.py
@@ -4,7 +4,7 @@ import os
 import logging
 import argparse
 import sys
-from tqdm import tqdm
+from alive_progress import alive_bar
 import yaml
 
 from bins import TimeRange
@@ -141,9 +141,9 @@ runner = gems_runner(
 
 try:
     total_needed = runner.time_ranges.needed
-    with tqdm(total=total_needed) as pbar:
+    with alive_bar(total=total_needed, manual=True) as pbar:
         while runner.run_step():
-            pbar.update(total_needed - runner.time_ranges.needed)
+            pbar(1 - runner.time_ranges.needed / total_needed)
     print("Done!")
 finally:
     runner.close()

--- a/data-collection/__main__.py
+++ b/data-collection/__main__.py
@@ -139,27 +139,10 @@ runner = gems_runner(
     praw_log_level=praw_log_level,
 )
 
-
-def run_in_terminal():
+try:
     total_needed = runner.time_ranges.needed
     with tqdm(total=total_needed) as pbar:
         while runner.run_step():
             pbar.update(total_needed - runner.time_ranges.needed)
-
-
-try:
-    if args.terminal:
-        run_in_terminal()
-    else:
-        # todo automatically detect if being run by streamlit instead
-        try:
-            import streamlit as _
-
-            from webapp import run_app
-
-            run_app(runner)
-        except ModuleNotFoundError:
-            # If Streamlit isn't installed, just run in the terminal normally
-            run_in_terminal()
 finally:
     runner.close()

--- a/data-collection/__main__.py
+++ b/data-collection/__main__.py
@@ -144,5 +144,6 @@ try:
     with tqdm(total=total_needed) as pbar:
         while runner.run_step():
             pbar.update(total_needed - runner.time_ranges.needed)
+    print("Done!")
 finally:
     runner.close()

--- a/data-collection/include.txt
+++ b/data-collection/include.txt
@@ -1,3 +1,4 @@
+alive-progress==3.1.5
 certifi==2024.2.2
 charset-normalizer==3.3.2
 idna==3.7
@@ -8,7 +9,6 @@ python-dotenv==1.0.1
 PyYaml==6.0.1
 requests==2.31.0
 streamlit==1.36.0
-tqdm==4.66.2
 update-checker==0.18.0
 urllib3==2.2.1
 websocket-client==1.8.0

--- a/data-collection/runner.py
+++ b/data-collection/runner.py
@@ -143,12 +143,15 @@ class gems_runner:
         self.logger.info("init complete")
 
     def accept(self, sock: socket.socket):
+        """Accept a new connection"""
         conn, addr = sock.accept()
         self.logger.info(f"Accepted connection from {addr}")
         conn.setblocking(False)
         self.sel.register(conn, selectors.EVENT_READ, True)
 
     def read(self, conn: socket.socket):
+        """Receive a message from the dashboard. We're not actually using this yet,
+        but we might want to allow stopping the server from the dashboard at some point"""
         try:
             data = conn.recv(1)
         except:
@@ -299,6 +302,8 @@ class gems_runner:
         for key, _mask in events:
             is_client = key.data
             if is_client:
+                # This isn't necessary yet, but at some point, we might want to
+                # receive messages from the dashboard
                 self.read(key.fileobj)
             else:
                 self.accept(key.fileobj)

--- a/data-collection/webapp.py
+++ b/data-collection/webapp.py
@@ -1,20 +1,45 @@
+from io import StringIO
+import logging
 import pandas as pd
+import selectors
+import socket
 import streamlit as st
 
-from runner import gems_runner
+logger = logging.Logger("dashboard")
+
+sel = selectors.DefaultSelector()
+
+hits_graph = st.empty()
+misses_graph = st.empty()
 
 
-def run_app(runner: gems_runner):
-    hits_graph = st.empty()
-    misses_graph = st.empty()
-    while runner.run_step():
-        df = pd.DataFrame(
-            [
-                [str(time_range.start_date), time_range.min, time_range.hits, time_range.misses]
-                for time_range in runner.time_ranges.bins
-            ],
-            columns=["Date", "Min", "Hits", "Misses"],
-        )
-        hits_graph.bar_chart(df, x="Date", y="Hits")
-        misses_graph.bar_chart(df, x="Date", y="Misses")
-    st.write("Done")
+def read(conn: socket.socket):
+    data = conn.recv(1024)
+    if not data:
+        logger.error(f"Closing {conn} (reason: got empty message)")
+        sel.unregister(conn)
+        conn.close()
+        raise Exception("Done")
+
+    logger.warning(f"Got {data!r}")
+    draw_graph(data.decode())
+
+
+def draw_graph(csv: str):
+    df = pd.read_csv(StringIO(csv))
+    hits_graph.bar_chart(df, x="Date", y="Hits")
+    misses_graph.bar_chart(df, x="Date", y="Misses")
+
+
+client_sock = socket.socket()
+client_sock.connect(("", 1234))
+client_sock.setblocking(False)
+sel.register(client_sock, selectors.EVENT_READ, read)
+
+while True:
+    events = sel.select()
+    print(events)
+    for key, _mask in events:
+        print(key)
+        callback = key.data
+        callback(key.fileobj)


### PR DESCRIPTION
This PR separates the web dashboard into a separate process. The data collector runs in one process and acts as a server, allowing connections on port 1234. The web dashboard acts as a client, so that it doesn't slow down the data collector, so that the data collector doesn't need to check if Streamlit is installed, and so that the data collector can do everything in the main thread (this allows it to change signal handlers to protect itself from being interrupted while saving results).

Data collector can still be run with `python data-collection`, web dashboard can be run with `streamlit run data-collection/webapp.py`.